### PR TITLE
feat(#35): Implementación de Pruebas de Rendimiento con Gatling

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.3'
     id "org.sonarqube" version "6.0.1.5171"
+    id 'io.gatling.gradle' version '3.10.3.1'
 }
 
 group = 'com.app'

--- a/backend/src/gatling/README.md
+++ b/backend/src/gatling/README.md
@@ -1,0 +1,87 @@
+# Pruebas de Rendimiento
+
+Este directorio contiene las pruebas de carga implementadas con **Gatling** para validar el rendimiento del backend bajo diferentes escenarios de uso.
+
+## Requisitos Previos
+
+1. El servidor backend debe estar ejecutándose en `http://localhost:8080`
+2. La base de datos debe estar disponible y poblada con datos de prueba
+
+## Ejecución de Pruebas
+
+### Ejecutar todas las simulaciones
+```bash
+./gradlew gatlingRun
+```
+
+### Ejecutar una simulación específica
+```bash
+# Login masivo
+./gradlew gatlingRun-simulations.LoginLoadSimulation
+
+# Lectura de posts
+./gradlew gatlingRun-simulations.PostReadLoadSimulation
+
+# Búsqueda (estrés)
+./gradlew gatlingRun-simulations.SearchLoadSimulation
+```
+
+## Escenarios Implementados
+
+### 1. LoginLoadSimulation
+- **Objetivo:** Validar la capacidad del sistema para manejar autenticaciones concurrentes
+- **Carga:** 10 usuarios/segundo durante 30 segundos (300 peticiones totales)
+- **Criterios de Éxito:**
+  - Tiempo de respuesta máximo < 2 segundos
+  - 95% de peticiones exitosas
+
+### 2. PostReadLoadSimulation
+- **Objetivo:** Medir rendimiento del endpoint más visitado (lectura de posts)
+- **Carga:** Escalamiento de 1 a 20 usuarios/segundo durante 1 minuto
+- **Criterios de Éxito:**
+  - Tiempo promedio de respuesta < 500ms
+  - 95% de peticiones < 1 segundo
+  - 99% de peticiones exitosas
+
+### 3. SearchLoadSimulation
+- **Objetivo:** Prueba de estrés sobre el motor de búsqueda (Hibernate Search)
+- **Carga:** 
+  - Rampeo: 5 → 50 usuarios/segundo durante 1 minuto
+  - Sostenido: 50 usuarios/segundo durante 30 segundos
+- **Criterios de Éxito:**
+  - 90% de peticiones < 2 segundos
+  - Menos del 5% de fallos
+
+## Reportes
+
+Después de ejecutar las pruebas, los reportes HTML se generan automáticamente en:
+```
+backend/build/reports/gatling/<nombre-simulacion>-<timestamp>/index.html
+```
+
+Abre el archivo `index.html` en tu navegador para visualizar:
+- Gráficos de tiempo de respuesta
+- Distribución de peticiones
+- Percentiles y estadísticas detalladas
+- Identificación de cuellos de botella
+
+## Interpretación de Resultados
+
+### Métricas Clave
+- **Response Time (mean):** Tiempo promedio de respuesta. Meta: < 500ms
+- **Response Time (95th percentile):** 95% de peticiones por debajo de este valor. Meta: < 1000ms
+- **Requests/sec:** Throughput del sistema. Valor base para comparaciones futuras
+- **Success Rate:** Porcentaje de peticiones exitosas. Meta: > 95%
+
+### Optimizaciones Sugeridas
+Si las pruebas revelan problemas, considera:
+1. **Caché:** Implementar Redis para consultas frecuentes
+2. **Índices de BD:** Revisar índices en tablas de posts y usuarios
+3. **Connection Pool:** Ajustar tamaño del pool de conexiones Hikari
+4. **Query Optimization:** Analizar queries lentas con logs de Hibernate
+
+## Notas Importantes
+
+- **No ejecutar en producción:** Estas pruebas generan carga significativa
+- **Ambiente aislado:** Idealmente ejecutar en un ambiente de staging
+- **Datos consistentes:** Usar el mismo dataset para comparar resultados entre ejecuciones

--- a/backend/src/gatling/java/simulations/LoginLoadSimulation.java
+++ b/backend/src/gatling/java/simulations/LoginLoadSimulation.java
@@ -1,0 +1,35 @@
+package simulations;
+
+import io.gatling.javaapi.core.*;
+import io.gatling.javaapi.http.*;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.*;
+
+public class LoginLoadSimulation extends Simulation {
+
+    // Configuración del protocolo HTTP
+    HttpProtocolBuilder httpProtocol = http
+            .baseUrl("http://localhost:8081")
+            .acceptHeader("application/json")
+            .contentTypeHeader("application/json");
+
+    // Escenario de login masivo
+    ScenarioBuilder loginScenario = scenario("Login Masivo")
+            .exec(
+                    http("Login Request")
+                            .post("/auth/login")
+                            .body(StringBody("{\"username\": \"testuser\", \"password\": \"password123\"}"))
+                            .check(status().in(200, 401)));
+
+    // Configuración de carga: 10 usuarios por segundo durante 30 segundos
+    {
+        setUp(
+                loginScenario.injectOpen(
+                        constantUsersPerSec(10).during(30)))
+                .protocols(httpProtocol)
+                .assertions(
+                        global().responseTime().max().lt(2000),
+                        global().successfulRequests().percent().gt(95.0));
+    }
+}

--- a/backend/src/gatling/java/simulations/PostReadLoadSimulation.java
+++ b/backend/src/gatling/java/simulations/PostReadLoadSimulation.java
@@ -1,0 +1,35 @@
+package simulations;
+
+import io.gatling.javaapi.core.*;
+import io.gatling.javaapi.http.*;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.*;
+
+public class PostReadLoadSimulation extends Simulation {
+
+  // Configuración del protocolo HTTP
+  HttpProtocolBuilder httpProtocol = http
+      .baseUrl("http://localhost:8081")
+      .acceptHeader("application/json");
+
+  // Escenario de lectura de posts
+  ScenarioBuilder postReadScenario = scenario("Lectura de Posts")
+      .exec(
+          http("Get Recent Posts")
+              .get("/post/getUltimatePosts")
+              .check(status().is(200)))
+      .pause(1, 3);
+
+  // Configuración de carga: escalamiento progresivo
+  {
+    setUp(
+        postReadScenario.injectOpen(
+            rampUsersPerSec(1).to(20).during(60)))
+        .protocols(httpProtocol)
+        .assertions(
+            global().responseTime().mean().lt(500),
+            global().responseTime().percentile(95.0).lt(1000),
+            global().successfulRequests().percent().gte(99.0));
+  }
+}

--- a/backend/src/gatling/java/simulations/SearchLoadSimulation.java
+++ b/backend/src/gatling/java/simulations/SearchLoadSimulation.java
@@ -1,0 +1,48 @@
+package simulations;
+
+import io.gatling.javaapi.core.*;
+import io.gatling.javaapi.http.*;
+import java.util.List;
+import java.util.Map;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.*;
+
+public class SearchLoadSimulation extends Simulation {
+
+        // Configuración del protocolo HTTP
+        HttpProtocolBuilder httpProtocol = http
+                        .baseUrl("http://localhost:8081")
+                        .acceptHeader("application/json");
+
+        // Feeder con términos de búsqueda diversos
+        FeederBuilder<String> searchTerms = listFeeder(
+                        List.of(
+                                        Map.of("query", "java"),
+                                        Map.of("query", "spring"),
+                                        Map.of("query", "error"),
+                                        Map.of("query", "ayuda"),
+                                        Map.of("query", "problema")))
+                        .circular();
+
+        // Escenario de búsqueda
+        ScenarioBuilder searchScenario = scenario("Búsqueda de Posts")
+                        .feed(searchTerms)
+                        .exec(
+                                        http("Search Posts")
+                                                        .get("/post/search/#{query}")
+                                                        .check(status().is(200)))
+                        .pause(2, 5);
+
+        // Prueba de estrés: carga progresiva hasta saturación
+        {
+                setUp(
+                                searchScenario.injectOpen(
+                                                rampUsersPerSec(5).to(50).during(60),
+                                                constantUsersPerSec(50).during(30)))
+                                .protocols(httpProtocol)
+                                .assertions(
+                                                global().responseTime().percentile(90.0).lt(2000),
+                                                global().failedRequests().percent().lt(5.0));
+        }
+}


### PR DESCRIPTION
Se implementó infraestructura de pruebas de carga usando Gatling para validar el rendimiento del backend bajo diferentes escenarios.

### Cambios:
- **Plugin Gatling** agregado a [build.gradle]
- **3 simulaciones de carga** implementadas:
  - [LoginLoadSimulation]: 10 req/seg durante 30s (autenticación)
  - [PostReadLoadSimulation]: Escalamiento 1→20 req/seg (lectura)
  - [SearchLoadSimulation]: Prueba de estrés 5→50 req/seg (búsqueda)

### Ejecución:
```bash
./gradlew gatlingRun
````
Closes #35